### PR TITLE
Support `aarch64-apple-darwin`

### DIFF
--- a/native/requiem_nif/.cargo/config
+++ b/native/requiem_nif/.cargo/config
@@ -3,3 +3,9 @@ rustflags = [
     "-C", "link-arg=-undefined",
     "-C", "link-arg=dynamic_lookup",
 ]
+
+[target.aarch64-apple-darwin]
+rustflags = [
+    "-C", "link-arg=-undefined",
+    "-C", "link-arg=dynamic_lookup",
+]


### PR DESCRIPTION
## WHY

On Apple Sillicon Mac, Requiem does not compile properly. When I run `mix archive.build` I get the following error (excerpt):

```bash
...
          ld: symbol(s) not found for architecture arm64
          clang: error: linker command failed with exit code 1 (use -v to see invocation)
          

error: could not compile `requiem_nif` due to previous error

== Compilation error in file lib/requiem/quic/nif.ex ==
** (RuntimeError) Rust NIF compile error (rustc exit code 101)
    (rustler 0.22.0) lib/rustler/compiler.ex:36: Rustler.Compiler.compile_crate/2
    lib/requiem/quic/nif.ex:2: (module)
    (stdlib 3.15) erl_eval.erl:685: :erl_eval.do_apply/6
```

## WHAT

Added `aarch64-apple-darwin` to target triple in cargo config. It passed `mix test`.